### PR TITLE
Fix stack-buffer-overflow in ClientBase::write_payload()

### DIFF
--- a/src/PicoWebsocket.cpp
+++ b/src/PicoWebsocket.cpp
@@ -167,7 +167,7 @@ size_t ClientBase::write_payload(const void * payload, const size_t size) {
         size_t written = 0;
         uint8_t buffer[buffer_size];
         while (written < size) {
-            const size_t chunk_size = size <= buffer_size ? size : buffer_size;
+            const size_t chunk_size =(size - written) < buffer_size ? (size - written) : buffer_size;
             memcpy(buffer, ((const char *) payload) + written, chunk_size);
             apply_mask(buffer, mask, chunk_size, written);
             if (!write_all(buffer, chunk_size)) {


### PR DESCRIPTION
### Summary
Fix **stack-buffer-overflow** in `ClientBase::write_payload()` when payload > 128 B.

### Impact
* Crash / reboot on ESP8266 / ESP32 devices (**DoS**)  
* Potential RCE on builds without stack-protector

### Technical details
`chunk_size` was always 128 B; the third loop copied past the end of the source
buffer. Patch limits `chunk_size` to `size - written` (one-line fix).

### Proof of concept (AddressSanitizer)

**Before (vulnerable build)**  
==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x…
READ of size 128 at 0x… in ClientBase::write_payload (mini_pico_vuln.cpp:20)
  [80,220) 'data'  <==  Memory access at 220 overflows this variable
SUMMARY: … in memcpy

**After (patched build)**

Same PoC re-compiled with the fixed line:
→ no sanitizer alerts — program exits with code 0


**Fix**
const size_t chunk_size =
    (size - written) < buffer_size ? (size - written) : buffer_size;

**Credits**
Discovered & patched by Sebastian Alba